### PR TITLE
Fix typo, default-base-image must be ":registry" instead of "registry".

### DIFF
--- a/src/leiningen/jib_build.clj
+++ b/src/leiningen/jib_build.clj
@@ -16,7 +16,7 @@
             [clojure.pprint :as pprint]
             [leiningen.core.project :as project]))
 
-(def default-base-image {:type registry
+(def default-base-image {:type :registry
                          :image-name "gcr.io/distroless/java"})
 (def default-entrypoint ["java" "-jar"])
 


### PR DESCRIPTION
Detail of exception when running from command line:

cd lein-jib-build-test
lein do uberjar, jib-build

...
#:clojure.error{:phase :compile-syntax-check, :line 19, :column 1, :source "leiningen/jib_build.clj"}
Caused by: java.lang.RuntimeException: Unable to resolve symbol: registry in this context